### PR TITLE
[Fix]: srcsets require a height to properly crop images

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,11 +83,11 @@ const getWidths = (width, maxWidth) => {
   return finalSizes
 }
 
-const srcSet = (srcBase, srcWidths, fit, transforms) =>
+const srcSet = (srcBase, srcWidths, srcHeight, fit, transforms) =>
   srcWidths
     .map(
       width =>
-        `${srcBase([`resize=w:${Math.floor(width)},fit:${fit}`])(
+        `${srcBase([`resize=w:${Math.floor(width)},h:${srcHeight},fit:${fit}`])(
           transforms
         )} ${Math.floor(width)}w`
     )
@@ -190,6 +190,7 @@ class GraphImage extends React.Component {
       const srcSetImgs = srcSet(
         srcBase,
         getWidths(width, maxWidth),
+        height,
         fit,
         transforms
       )


### PR DESCRIPTION
I found an issue where srcsets being generated did not contain the `height` attribute which means you are unable to crop.  I researched the problem and found issue #41 where at least one other user noted the same problem.

This PR resolves #41 

**[Screenshot before - fit:crop]:**
![before-crop](https://github.com/hygraph/react-image/assets/5696449/b6041d97-7b31-4687-b394-38817d7aa5d5)
**[Screenshot after - fit:crop]:**
![after-crop](https://github.com/hygraph/react-image/assets/5696449/40dd931b-f40a-4076-82d4-df30c2b3c41a)
